### PR TITLE
Wrap html output with `rawhtml` shortcode

### DIFF
--- a/nb2hugo/exporter.py
+++ b/nb2hugo/exporter.py
@@ -1,18 +1,26 @@
 from nbconvert.exporters import MarkdownExporter
 from traitlets import List
-from .preprocessors import (FrontMatterPreprocessor, FixLatexPreprocessor,
-                            ImagesPreprocessor, RawPreprocessor)
+from .preprocessors import (
+    FrontMatterPreprocessor,
+    FixLatexPreprocessor,
+    ImagesPreprocessor,
+    RawPreprocessor,
+    WrapHtmlPreprocessor,
+)
+
 
 class HugoExporter(MarkdownExporter):
     """Export a Jupyter notebook to a pair of markdown and resources
     compatible with Hugo.
     """
-    
-    preprocessors = List([
+
+    preprocessors = List(
+        [
             FrontMatterPreprocessor,
             FixLatexPreprocessor,
             RawPreprocessor,
             ImagesPreprocessor,
+            WrapHtmlPreprocessor,
         ],
-        help="""List of preprocessors, by name or namespace, to enable."""
+        help="""List of preprocessors, by name or namespace, to enable.""",
     ).tag(config=True)

--- a/nb2hugo/preprocessors/__init__.py
+++ b/nb2hugo/preprocessors/__init__.py
@@ -2,3 +2,4 @@ from .fixlatex import FixLatexPreprocessor
 from .frontmatter import FrontMatterPreprocessor
 from .images import ImagesPreprocessor
 from .raw import RawPreprocessor
+from .htmlwrapper import WrapHtmlPreprocessor

--- a/nb2hugo/preprocessors/htmlwrapper.py
+++ b/nb2hugo/preprocessors/htmlwrapper.py
@@ -1,0 +1,28 @@
+from nbconvert.preprocessors import Preprocessor
+
+
+class WrapHtmlPreprocessor(Preprocessor):
+    """
+    Wraps html ouput from cells in the shortcode `rawhtml`.
+
+    The `rawhtml` shortcode is a file which should be placed in `layouts/shortcodes/rawhtml.html` with this contents:
+
+        <!-- raw html -->
+        {{.Inner}}
+
+    Hugo starting from version 0.60 (see discussion: https://discourse.gohugo.io/t/raw-html-getting-omitted-in-0-60-0/22032)
+    doesn't render html tags by default, it needs the `unsafe = true` flag instead.
+
+    However, it doesn't handle blocks of HTML very well even if `unsafe = true` in the config.toml and the approach of
+    having a shortcode works better.
+    """
+
+    def preprocess_cell(self, cell, resources, index):
+        outputs = cell.get("outputs", [])
+        for output in outputs:
+            data = output.get("data", {})
+            if "text/html" in data:
+                data["text/html"] = (
+                    "{{< rawhtml >}}\n" + data["text/html"] + "\n{{< /rawhtml >}}"
+                )
+        return cell, resources

--- a/tests/preprocessors/test_htmlwrapper.py
+++ b/tests/preprocessors/test_htmlwrapper.py
@@ -1,0 +1,38 @@
+import pytest
+from nbformat import notebooknode
+from nb2hugo.preprocessors import WrapHtmlPreprocessor
+from copy import deepcopy
+
+
+@pytest.fixture
+def preprocessor():
+    return WrapHtmlPreprocessor()
+
+
+cell_without_outputs = notebooknode.from_dict({})
+cell_with_empty_outputs = notebooknode.from_dict({"outputs": []})
+cell_without_data_in_outputs = notebooknode.from_dict({"outputs": [{"name": "stdout"}]})
+cell_without_html_in_outputs = notebooknode.from_dict(
+    {"outputs": [{"data": {"text/plain": "text"}}]}
+)
+cell_with_text_html_in_outputs = notebooknode.from_dict(
+    {"outputs": [{"data": {"text/html": "html"}}]}
+)
+transformed_cell_with_text_html_in_outputs = notebooknode.from_dict(
+    {"outputs": [{"data": {"text/html": "{{< rawhtml >}}\nhtml\n{{< /rawhtml >}}"}}]}
+)
+
+
+@pytest.mark.parametrize(
+    "input_cell, expected_cell",
+    [
+        (cell_without_outputs, cell_without_outputs),
+        (cell_with_empty_outputs, cell_with_empty_outputs),
+        (cell_without_data_in_outputs, cell_without_data_in_outputs),
+        (cell_without_html_in_outputs, cell_without_html_in_outputs),
+        (cell_with_text_html_in_outputs, transformed_cell_with_text_html_in_outputs),
+    ],
+)
+def test_preprocess_cell(preprocessor, input_cell, expected_cell):
+    result = preprocessor.preprocess_cell(deepcopy(input_cell), None, None)
+    assert result[0] == expected_cell


### PR DESCRIPTION
This makes possible to render html outputs using nb2hugo.

See this example: https://edisongustavo.github.io/posts/hello-jupyter/

While I don't like the idea of requiring a shortcode in the users installation, I couldn't find a way to do this with only builtin Hugo shortcodes. If there is a way, I'm all ears to implement it.